### PR TITLE
Don't use releasever to peg Rocky Linux 9

### DIFF
--- a/rockylinux-9/Containerfile-fixed
+++ b/rockylinux-9/Containerfile-fixed
@@ -1,9 +1,9 @@
-FROM docker.io/library/rockylinux:${releasever}
+FROM docker.io/library/rockylinux:${release}
 
 RUN sed -i /etc/yum.repos.d/rocky*.repo \
       -e 's/^#baseurl=/baseurl=/' \
       -e 's/^mirrorlist=/#mirrorlist=/' \
-    && echo "${releasever}" >/etc/dnf/vars/releasever \
+      -e 's/\$releasever/${release}/' \
     && dnf clean all
 
 RUN dnf update -y \

--- a/rockylinux-9/Containerfile-vault
+++ b/rockylinux-9/Containerfile-vault
@@ -1,10 +1,10 @@
-FROM docker.io/library/rockylinux:${releasever}
+FROM docker.io/library/rockylinux:${release}
 
 RUN sed -i /etc/yum.repos.d/rocky*.repo \
       -e 's/^#baseurl=/baseurl=/' \
       -e 's/^mirrorlist=/#mirrorlist=/' \
+      -e 's/\$releasever/${release}/' \
     && echo 'vault/rocky' >/etc/dnf/vars/contentdir \
-    && echo "${releasever}" >/etc/dnf/vars/releasever \
     && dnf clean all
 
 RUN dnf update -y \

--- a/rockylinux-9/Makefile
+++ b/rockylinux-9/Makefile
@@ -9,7 +9,7 @@ clean:
 	rm -f Containerfile-9.*
 
 Containerfile-9.%: Containerfile-vault
-	env releasever=9.$* envsubst <Containerfile-vault >$@
+	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
 Containerfile-9.3: Containerfile-fixed
-	env releasever=9.3 envsubst <Containerfile-fixed >$@
+	env release=9.3 envsubst '$$release' <Containerfile-fixed >$@


### PR DESCRIPTION
EPEL9 uses `$releasever` and doesn't consider point releases valid; so we can't use it to peg Rocky Linux 9 to a given point release. Use raw string substitution in stead.

Fixes #47