### PR TITLE
Update Rocky Linux 9 for 9.5

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -67,6 +67,10 @@ jobs:
             version: "9.4"
             context: rockylinux-9
             file: rockylinux-9/Containerfile-9.4
+          - os: rockylinux
+            version: "9.5"
+            context: rockylinux-9
+            file: rockylinux-9/Containerfile-9.5
           - os: leap
             version: "15"
             context: leap

--- a/rockylinux-9/Containerfile
+++ b/rockylinux-9/Containerfile
@@ -26,6 +26,7 @@ RUN dnf update -y \
       wget \
       which \
       words \
+    && dnf remove -y selinux-policy \
     && dnf clean all
 
 COPY excludes /etc/warewulf/

--- a/rockylinux-9/Containerfile-fixed
+++ b/rockylinux-9/Containerfile-fixed
@@ -32,6 +32,7 @@ RUN dnf update -y \
       wget \
       which \
       words \
+    && dnf remove -y selinux-policy \
     && dnf clean all
 
 COPY excludes /etc/warewulf/

--- a/rockylinux-9/Containerfile-vault
+++ b/rockylinux-9/Containerfile-vault
@@ -33,6 +33,7 @@ RUN dnf update -y \
       wget \
       which \
       words \
+    && dnf remove -y selinux-policy \
     && dnf clean all
 
 COPY excludes /etc/warewulf/

--- a/rockylinux-9/Makefile
+++ b/rockylinux-9/Makefile
@@ -3,6 +3,7 @@ all: Containerfile-9.0
 all: Containerfile-9.1
 all: Containerfile-9.2
 all: Containerfile-9.3
+all: Containerfile-9.5
 all: Containerfile-9.4
 
 .PHONY: clean
@@ -12,5 +13,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.4: Containerfile-fixed
-	env release=9.4 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.5: Containerfile-fixed
+	env release=9.5 envsubst '$$release' <Containerfile-fixed >$@


### PR DESCRIPTION
- Rock Linux 9.4 moved to vault
- Rocky Linux 9.x now explicitly removes selinux-policy