### PR TITLE
Add helper support to Rocky Linux images for warewulf-dracut

### DIFF
--- a/rockylinux-8/Containerfile
+++ b/rockylinux-8/Containerfile
@@ -40,6 +40,7 @@ RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
+COPY warewulf-dracut-rebuild.sh /usr/local/libexec/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-8/Containerfile-fixed
+++ b/rockylinux-8/Containerfile-fixed
@@ -43,6 +43,7 @@ RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
+COPY warewulf-dracut-rebuild.sh /usr/local/libexec/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-8/Containerfile-vault
+++ b/rockylinux-8/Containerfile-vault
@@ -47,6 +47,7 @@ RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
+COPY warewulf-dracut-rebuild.sh /usr/local/libexec/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-8/container_exit.sh
+++ b/rockylinux-8/container_exit.sh
@@ -11,5 +11,11 @@ https://rockylinux.org/support
 
 export LANG=C LC_CTYPE=C
 
+rm -f /etc/machine-id
+if rpm -q warewulf-dracut --quiet
+then
+	dracut --no-hostonly --add wwinit --regenerate-all
+fi
+
 set -x
 dnf clean all

--- a/rockylinux-8/warewulf-dracut-rebuild.sh
+++ b/rockylinux-8/warewulf-dracut-rebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if rpm -q warewulf-dracut --quiet
+then
+	dracut --force --no-hostonly --add wwinit --regenerate-all
+else
+	echo 1>&2 "warewulf-dracut not found"
+	exit -1
+fi

--- a/rockylinux-9/Containerfile
+++ b/rockylinux-9/Containerfile
@@ -33,6 +33,7 @@ RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
+COPY warewulf-dracut-rebuild.sh /usr/local/libexec/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-9/Containerfile-fixed
+++ b/rockylinux-9/Containerfile-fixed
@@ -39,6 +39,7 @@ RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
+COPY warewulf-dracut-rebuild.sh /usr/local/libexec/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-9/Containerfile-vault
+++ b/rockylinux-9/Containerfile-vault
@@ -40,6 +40,7 @@ RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
+COPY warewulf-dracut-rebuild.sh /usr/local/libexec/
 
 CMD [ "/bin/echo", "-e", \
       "This image is intended to be used with the Warewulf cluster management and", \

--- a/rockylinux-9/container_exit.sh
+++ b/rockylinux-9/container_exit.sh
@@ -2,14 +2,20 @@
 
 echo "
 The Rocky Linux community provides updates for the latest point release of
-Rocky Linux 9. If you need to remain on a specific point release (e.g., Rocky
-Linux 9.2) you may want to engage with a commercial support provider for
+Rocky Linux 8. If you need to remain on a specific point release (e.g., Rocky
+Linux 8.8) you may want to engage with a commercial support provider for
 long-term support.
 
 https://rockylinux.org/support
 "
 
 export LANG=C LC_CTYPE=C
+
+rm -f /etc/machine-id
+if rpm -q warewulf-dracut --quiet
+then
+	dracut --no-hostonly --add wwinit --regenerate-all
+fi
 
 set -x
 dnf clean all

--- a/rockylinux-9/warewulf-dracut-rebuild.sh
+++ b/rockylinux-9/warewulf-dracut-rebuild.sh
@@ -1,0 +1,9 @@
+#!/bin/sh
+
+if rpm -q warewulf-dracut --quiet
+then
+	dracut --force --no-hostonly --add wwinit --regenerate-all
+else
+	echo 1>&2 "warewulf-dracut not found"
+	exit -1
+fi


### PR DESCRIPTION
- If warewulf-dracut is installed, automatically generate initrd on exit
- Helper script in libexec for force-regenerating initrd