### PR TITLE
Wait for image to come fully online with NetworkManager-wait-online.service

### DIFF
--- a/almalinux-9/Containerfile
+++ b/almalinux-9/Containerfile
@@ -1,5 +1,6 @@
 FROM docker.io/library/almalinux:9
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-9/Containerfile
+++ b/almalinux-9/Containerfile
@@ -33,6 +33,7 @@ RUN dnf update -y \
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 RUN userdel systemd-oom # remove unused dynamic system user
 
+COPY etc/ /etc/
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
 

--- a/almalinux-9/Containerfile-fixed
+++ b/almalinux-9/Containerfile-fixed
@@ -6,6 +6,7 @@ RUN sed -i /etc/yum.repos.d/almalinux*.repo \
       -e 's/\$releasever/${release}/' \
     && dnf clean all
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-9/Containerfile-fixed
+++ b/almalinux-9/Containerfile-fixed
@@ -39,6 +39,7 @@ RUN dnf update -y \
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 RUN userdel systemd-oom # remove unused dynamic system user
 
+COPY etc/ /etc/
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
 

--- a/almalinux-9/Containerfile-vault
+++ b/almalinux-9/Containerfile-vault
@@ -39,6 +39,7 @@ RUN dnf update -y \
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 RUN userdel systemd-oom # remove unused dynamic system user
 
+COPY etc/ /etc/
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
 

--- a/almalinux-9/etc/systemd/system/NetworkManager-wait-online.service.d/override.conf
+++ b/almalinux-9/etc/systemd/system/NetworkManager-wait-online.service.d/override.conf
@@ -1,0 +1,7 @@
+# Require the network to come fully online by removing `-s` from
+# the nm-online command (see `man nm-online`).
+# https://github.com/openhpc/ohpc/issues/2091
+[Service]
+ExecStart=
+ExecStart=/usr/bin/nm-online -q
+EOF

--- a/rockylinux-9/Containerfile
+++ b/rockylinux-9/Containerfile
@@ -31,6 +31,7 @@ RUN dnf update -y \
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
+COPY etc/ /etc/
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
 

--- a/rockylinux-9/Containerfile-fixed
+++ b/rockylinux-9/Containerfile-fixed
@@ -37,6 +37,7 @@ RUN dnf update -y \
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
+COPY etc/ /etc/
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
 

--- a/rockylinux-9/Containerfile-vault
+++ b/rockylinux-9/Containerfile-vault
@@ -38,6 +38,7 @@ RUN dnf update -y \
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
 
+COPY etc/ /etc/
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/
 

--- a/rockylinux-9/etc/systemd/system/NetworkManager-wait-online.service.d/override.conf
+++ b/rockylinux-9/etc/systemd/system/NetworkManager-wait-online.service.d/override.conf
@@ -1,0 +1,7 @@
+# Require the network to come fully online by removing `-s` from
+# the nm-online command (see `man nm-online`).
+# https://github.com/openhpc/ohpc/issues/2091
+[Service]
+ExecStart=
+ExecStart=/usr/bin/nm-online -q
+EOF


### PR DESCRIPTION
`NetworkManger-wait-online.service` does not seem to properly wait for the node to come online fully during boot, Issue warewulf/warewulf#1859 .   This PR removes the `-s` from nm-online called in the service, which makes NetworkManager come online after it loads.  This patch is applied here since putting it in the NetworkManager overlay would apply it to all distributions/versions.

Patch applied to Rocky Linux 9 and Alma Linux 9.

Also addresses missing `/boot` in recent AlmaLinux containers, Issue #72 .
