### PR TITLE
Upgrade EL9 and remove extra versions

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -28,14 +28,6 @@ jobs:
             context: rockylinux-8
             file: rockylinux-8/Containerfile
           - os: rockylinux
-            version: 8.7
-            context: rockylinux-8
-            file: rockylinux-8/Containerfile-8.7
-          - os: rockylinux
-            version: "8.8"
-            context: rockylinux-8
-            file: rockylinux-8/Containerfile-8.8
-          - os: rockylinux
             version: "8.9"
             context: rockylinux-8
             file: rockylinux-8/Containerfile-8.9
@@ -48,41 +40,17 @@ jobs:
             context: rockylinux-9
             file: rockylinux-9/Containerfile
           - os: rockylinux
-            version: "9.0"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.0
-          - os: rockylinux
-            version: "9.1"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.1
-          - os: rockylinux
-            version: "9.2"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.2
-          - os: rockylinux
-            version: "9.3"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.3
-          - os: rockylinux
-            version: "9.4"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.4
-          - os: rockylinux
             version: "9.5"
             context: rockylinux-9
             file: rockylinux-9/Containerfile-9.5
+          - os: rockylinux
+            version: "9.6"
+            context: rockylinux-9
+            file: rockylinux-9/Containerfile-9.6
           - os: almalinux
             version: "8"
             context: almalinux-8
             file: almalinux-8/Containerfile
-          - os: almalinux
-            version: 8.7
-            context: almalinux-8
-            file: almalinux-8/Containerfile-8.7
-          - os: almalinux
-            version: "8.8"
-            context: almalinux-8
-            file: almalinux-8/Containerfile-8.8
           - os: almalinux
             version: "8.9"
             context: almalinux-8
@@ -96,29 +64,13 @@ jobs:
             context: almalinux-9
             file: almalinux-9/Containerfile
           - os: almalinux
-            version: "9.0"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.0
-          - os: almalinux
-            version: "9.1"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.1
-          - os: almalinux
-            version: "9.2"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.2
-          - os: almalinux
-            version: "9.3"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.3
-          - os: almalinux
-            version: "9.4"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.4
-          - os: almalinux
             version: "9.5"
             context: almalinux-9
             file: almalinux-9/Containerfile-9.5
+          - os: almalinux
+            version: "9.6"
+            context: almalinux-9
+            file: almalinux-9/Containerfile-9.6
           - os: leap
             version: "15"
             context: leap

--- a/almalinux-8/Makefile
+++ b/almalinux-8/Makefile
@@ -1,6 +1,4 @@
 .PHONY: all
-all: Containerfile-8.7
-all: Containerfile-8.8
 all: Containerfile-8.9
 all: Containerfile-8.10
 

--- a/almalinux-9/Containerfile
+++ b/almalinux-9/Containerfile
@@ -30,7 +30,6 @@ RUN dnf update -y \
     && dnf clean all
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
-RUN userdel systemd-oom # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-9/Containerfile-fixed
+++ b/almalinux-9/Containerfile-fixed
@@ -36,7 +36,6 @@ RUN dnf update -y \
     && dnf clean all
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
-RUN userdel systemd-oom # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-9/Makefile
+++ b/almalinux-9/Makefile
@@ -1,10 +1,6 @@
 .PHONY: all
-all: Containerfile-9.0
-all: Containerfile-9.1
-all: Containerfile-9.2
-all: Containerfile-9.3
 all: Containerfile-9.5
-all: Containerfile-9.4
+all: Containerfile-9.6
 
 .PHONY: clean
 clean:
@@ -13,5 +9,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.5: Containerfile-fixed
-	env release=9.5 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.6: Containerfile-fixed
+	env release=9.6 envsubst '$$release' <Containerfile-fixed >$@

--- a/rockylinux-8/Makefile
+++ b/rockylinux-8/Makefile
@@ -1,6 +1,4 @@
 .PHONY: all
-all: Containerfile-8.7
-all: Containerfile-8.8
 all: Containerfile-8.9
 all: Containerfile-8.10
 

--- a/rockylinux-9/Makefile
+++ b/rockylinux-9/Makefile
@@ -1,10 +1,6 @@
 .PHONY: all
-all: Containerfile-9.0
-all: Containerfile-9.1
-all: Containerfile-9.2
-all: Containerfile-9.3
 all: Containerfile-9.5
-all: Containerfile-9.4
+all: Containerfile-9.6
 
 .PHONY: clean
 clean:
@@ -13,5 +9,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.5: Containerfile-fixed
-	env release=9.5 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.6: Containerfile-fixed
+	env release=9.6 envsubst '$$release' <Containerfile-fixed >$@


### PR DESCRIPTION
* Upgrade Rocky and AlmaLinux images to 9.6
* Remove older images as discussed in TSC, rolling and last two numbered versions), currently 9, 9.5, and 9.6 respectively.
* Since git-hub actions are run from the main branch, successful build run at: https://github.com/middelkoopt/warewulf-node-images/actions/runs/15807131056