### PR TITLE
Add openEuler node image

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -87,6 +87,10 @@ jobs:
             version: "12.0"
             context: debian
             file: debian/Containerfile-12.0
+          - os: openeuler
+            version: "24.03"
+            context: openeuler-24.03
+            file: openeuler-24.03/Containerfile
 
     permissions:
       contents: read

--- a/openeuler-24.03/Containerfile
+++ b/openeuler-24.03/Containerfile
@@ -1,0 +1,46 @@
+FROM docker.io/openeuler/openeuler:24.03-lts-sp2
+
+RUN dnf install -y --allowerasing \
+      kernel \
+      kernel-devel \
+      kernel-headers \
+      kernel-modules \
+      python3-dnf-plugin-versionlock \
+      coreutils \
+      cpio \
+      dhclient \
+      e2fsprogs \
+      ethtool \
+      findutils \
+      initscripts \
+      ipmitool \
+      iproute \
+      ncurses \
+      net-tools \
+      NetworkManager \
+      nfs-utils \
+      openssh-clients \
+      openssh-server \
+      pciutils \
+      policycoreutils-python-utils \
+      psmisc \
+      rsync \
+      rsyslog \
+      strace \
+      selinux-policy-targeted \
+      wget \
+      which \
+      words \
+      rdma-core \
+    && dnf clean all
+
+COPY excludes /etc/warewulf/
+COPY container_exit.sh /etc/warewulf/
+RUN chmod +x /etc/warewulf/container_exit.sh
+RUN echo 'LANG="C.UTF-8"' > /etc/locale.conf
+
+CMD [ "/bin/echo", "-e", \
+      "This image is intended to be used with the Warewulf cluster management and", \
+      "\nprovisioning system.", \
+      "\n", \
+      "\nFor more information about Warewulf, visit https://warewulf.org" ]

--- a/openeuler-24.03/README.md
+++ b/openeuler-24.03/README.md
@@ -1,0 +1,10 @@
+# openEuler 24.03
+
+A Warewulf container definition based on openEuler 24.03.
+
+```
+podman build . -t warewulf/warewulf-openeuler:24.03
+```
+
+As service packs (SP) for the LTS version are released regularly, 
+we also need to update the openEuler image version used in the Containerfile periodically.

--- a/openeuler-24.03/container_exit.sh
+++ b/openeuler-24.03/container_exit.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -x
+LANG=C
+LC_CTYPE=C
+export LANG LC_CTYPE
+dnf clean all
+rm -f /etc/machine-id /var/lib/dbus/machine-id

--- a/openeuler-24.03/excludes
+++ b/openeuler-24.03/excludes
@@ -1,0 +1,2 @@
+/boot/
+/usr/share/GeoIP


### PR DESCRIPTION
Within an OpenHPC environment, we plan to use Warewulf 4 to boot and provision openEuler 24.03 as the node image. Therefore, we are submitting the openEuler 24.03 image here as the first step.