### PR TITLE
Truncate /etc/machine-id to bypass first-boot semantics

### DIFF
--- a/almalinux-10/container_exit.sh
+++ b/almalinux-10/container_exit.sh
@@ -13,4 +13,5 @@ export LANG=C LC_CTYPE=C
 
 set -x
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/almalinux-8/container_exit.sh
+++ b/almalinux-8/container_exit.sh
@@ -13,4 +13,5 @@ export LANG=C LC_CTYPE=C
 
 set -x
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/almalinux-9/container_exit.sh
+++ b/almalinux-9/container_exit.sh
@@ -13,4 +13,5 @@ export LANG=C LC_CTYPE=C
 
 set -x
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/debian/container_exit.sh
+++ b/debian/container_exit.sh
@@ -4,4 +4,5 @@ LANG=C
 LC_CTYPE=C
 export LANG LC_CTYPE
 apt-get clean
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/examples/rhel-9/container_exit.sh
+++ b/examples/rhel-9/container_exit.sh
@@ -4,4 +4,5 @@ LANG=C
 LC_CTYPE=C
 export LANG LC_CTYPE
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/examples/rockylinux-mofed/Containerfile-8
+++ b/examples/rockylinux-mofed/Containerfile-8
@@ -23,4 +23,5 @@ RUN dnf -y install \
 
 RUN (cd /tmp && tar -xf /mnt/$MOFED_TGZ) \
     && (cd /tmp/MLNX_OFED_LINUX* && ./mlnxofedinstall --distro rhel8.10 --skip-repo --kernel $(rpm -q kernel-core --qf '%{version}-%{release}.%{arch}\n' | tail -n 1) --add-kernel-support --hpc --without-fw-update) \
-    && rm -rf /tmp/MLNX_OFED_LINUX* /etc/machine-id
+    && rm -rf /tmp/MLNX_OFED_LINUX* \
+    && truncate -s0 /etc/machine-id

--- a/examples/rockylinux-mofed/Containerfile-9
+++ b/examples/rockylinux-mofed/Containerfile-9
@@ -25,4 +25,5 @@ RUN dnf -y install \
 
 RUN (cd /tmp && tar -xf /mnt/$MOFED_TGZ) \
     && (cd /tmp/MLNX_OFED_LINUX* && ./mlnxofedinstall --distro rhel9.4 --skip-repo --kernel $(rpm -q kernel-core --qf '%{version}-%{release}.%{arch}\n' | tail -n 1) --add-kernel-support --hpc --without-fw-update) \
-    && rm -rf /tmp/MLNX_OFED_LINUX* /etc/machine-id
+    && rm -rf /tmp/MLNX_OFED_LINUX* \
+    && truncate -s0 /etc/machine-id

--- a/leap/container_exit.sh
+++ b/leap/container_exit.sh
@@ -2,4 +2,5 @@
 export LANG=C LC_CTYPE=C
 set -x
 zypper clean -a
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/openeuler-24.03/container_exit.sh
+++ b/openeuler-24.03/container_exit.sh
@@ -4,4 +4,5 @@ LANG=C
 LC_CTYPE=C
 export LANG LC_CTYPE
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/rockylinux-10/container_exit.sh
+++ b/rockylinux-10/container_exit.sh
@@ -13,4 +13,5 @@ export LANG=C LC_CTYPE=C
 
 set -x
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/rockylinux-8/container_exit.sh
+++ b/rockylinux-8/container_exit.sh
@@ -13,4 +13,5 @@ export LANG=C LC_CTYPE=C
 
 set -x
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/rockylinux-9/container_exit.sh
+++ b/rockylinux-9/container_exit.sh
@@ -13,4 +13,5 @@ export LANG=C LC_CTYPE=C
 
 set -x
 dnf clean all
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id

--- a/tumbleweed/container_exit.sh
+++ b/tumbleweed/container_exit.sh
@@ -2,4 +2,5 @@
 export LANG=C LC_CTYPE=C
 set -x
 zypper clean -a
-rm -f /etc/machine-id /var/lib/dbus/machine-id
+rm -f /var/lib/dbus/machine-id
+truncate -s0 /etc/machine-id


### PR DESCRIPTION
We have previously configured node images to remove /etc/machine-id to prevent all compute nodes from having the same machine-id. However, this provokes first-boot semantics which, in Enterprise Linux 10, means that services that are not enabled by preset do not start.

Placing an empty /etc/machine-id bypasses first-boot semantics, allowing enabled services to start as expected.

- Fixes: warewulf/warewulf#2018

See also: https://www.man7.org/linux/man-pages/man5/machine-id.5.html

> If /etc/machine-id exists and is empty, a boot is not considered the first
> boot.  systemd will still bind-mount a file containing the actual machine-id
> over it and later try to commit it to disk (if /etc/ is writable).