### PR TITLE
Create missing /boot in AlmaLinux

### DIFF
--- a/almalinux-10/Containerfile
+++ b/almalinux-10/Containerfile
@@ -1,5 +1,6 @@
 FROM docker.io/library/almalinux:10
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-10/Containerfile-fixed
+++ b/almalinux-10/Containerfile-fixed
@@ -6,6 +6,7 @@ RUN sed -i /etc/yum.repos.d/almalinux*.repo \
       -e 's/\$releasever/${release}/' \
     && dnf clean all
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-10/Containerfile-vault
+++ b/almalinux-10/Containerfile-vault
@@ -7,6 +7,7 @@ RUN sed -i /etc/yum.repos.d/almalinux*.repo \
       -e 's|/almalinux/|/vault/|' \
     && dnf clean all
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-9/Containerfile
+++ b/almalinux-9/Containerfile
@@ -1,5 +1,6 @@
 FROM docker.io/library/almalinux:9
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-9/Containerfile-fixed
+++ b/almalinux-9/Containerfile-fixed
@@ -6,6 +6,7 @@ RUN sed -i /etc/yum.repos.d/almalinux*.repo \
       -e 's/\$releasever/${release}/' \
     && dnf clean all
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \

--- a/almalinux-9/Containerfile-vault
+++ b/almalinux-9/Containerfile-vault
@@ -7,6 +7,7 @@ RUN sed -i /etc/yum.repos.d/almalinux*.repo \
       -e 's|/almalinux/|/vault/|' \
     && dnf clean all
 
+RUN mkdir /boot # missing in the container
 RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \


### PR DESCRIPTION
AlmaLinux does not have a `/boot/` directory in the container/image.  Creating a `/boot` directory to be symmetric with Rocky Linux.  Kernel packages expect this to be there, used for provision-to-disk (OpenHPC 4.x)
