### PR TITLE
Update to EL9.7, EL10.1, remove dhclient and words

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -40,13 +40,13 @@ jobs:
             context: rockylinux-9
             file: rockylinux-9/Containerfile
           - os: rockylinux
-            version: "9.5"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.5
-          - os: rockylinux
             version: "9.6"
             context: rockylinux-9
             file: rockylinux-9/Containerfile-9.6
+          - os: rockylinux
+            version: "9.7"
+            context: rockylinux-9
+            file: rockylinux-9/Containerfile-9.7
           - os: rockylinux
             version: "10"
             context: rockylinux-10
@@ -55,6 +55,10 @@ jobs:
             version: "10.0"
             context: rockylinux-10
             file: rockylinux-10/Containerfile-10.0
+          - os: rockylinux
+            version: "10.1"
+            context: rockylinux-10
+            file: rockylinux-10/Containerfile-10.1
           - os: almalinux
             version: "8"
             context: almalinux-8
@@ -72,13 +76,13 @@ jobs:
             context: almalinux-9
             file: almalinux-9/Containerfile
           - os: almalinux
-            version: "9.5"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.5
-          - os: almalinux
             version: "9.6"
             context: almalinux-9
             file: almalinux-9/Containerfile-9.6
+          - os: almalinux
+            version: "9.7"
+            context: almalinux-9
+            file: almalinux-9/Containerfile-9.7
           - os: almalinux
             version: "10"
             context: almalinux-10
@@ -87,6 +91,10 @@ jobs:
             version: "10.0"
             context: almalinux-10
             file: almalinux-10/Containerfile-10.0
+          - os: almalinux
+            version: "10.1"
+            context: almalinux-10
+            file: almalinux-10/Containerfile-10.1
           - os: leap
             version: "15"
             context: leap

--- a/almalinux-10/Containerfile
+++ b/almalinux-10/Containerfile
@@ -25,7 +25,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 

--- a/almalinux-10/Containerfile-fixed
+++ b/almalinux-10/Containerfile-fixed
@@ -31,7 +31,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 

--- a/almalinux-10/Containerfile-vault
+++ b/almalinux-10/Containerfile-vault
@@ -32,7 +32,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 

--- a/almalinux-10/Makefile
+++ b/almalinux-10/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all
 all: Containerfile-10.0
+all: Containerfile-10.1
 
 .PHONY: clean
 clean:
@@ -8,5 +9,5 @@ clean:
 Containerfile-10.%: Containerfile-vault
 	env release=10.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-10.0: Containerfile-fixed
-	env release=10.0 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-10.1: Containerfile-fixed
+	env release=10.1 envsubst '$$release' <Containerfile-fixed >$@

--- a/almalinux-8/Containerfile
+++ b/almalinux-8/Containerfile
@@ -4,7 +4,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -25,7 +24,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf clean all
 
 RUN systemctl unmask \
@@ -37,6 +35,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-8/Containerfile-fixed
+++ b/almalinux-8/Containerfile-fixed
@@ -7,7 +7,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -28,7 +27,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf clean all
 
 RUN systemctl unmask \
@@ -40,6 +38,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-8/Containerfile-vault
+++ b/almalinux-8/Containerfile-vault
@@ -11,7 +11,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -32,7 +31,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf clean all
 
 RUN systemctl unmask \
@@ -44,6 +42,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-9/Containerfile
+++ b/almalinux-9/Containerfile
@@ -5,7 +5,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -26,7 +25,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 
@@ -39,6 +37,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-9/Containerfile-fixed
+++ b/almalinux-9/Containerfile-fixed
@@ -11,7 +11,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -32,7 +31,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 
@@ -45,6 +43,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-9/Containerfile-vault
+++ b/almalinux-9/Containerfile-vault
@@ -12,7 +12,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -33,7 +32,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 
@@ -46,7 +44,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
-RUN userdel systemd-oom # remove unused dynamic system user
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/almalinux-9/Makefile
+++ b/almalinux-9/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
-all: Containerfile-9.5
 all: Containerfile-9.6
+all: Containerfile-9.7
 
 .PHONY: clean
 clean:
@@ -9,5 +9,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.6: Containerfile-fixed
-	env release=9.6 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.7: Containerfile-fixed
+	env release=9.7 envsubst '$$release' <Containerfile-fixed >$@

--- a/examples/rhel-9/Containerfile
+++ b/examples/rhel-9/Containerfile
@@ -9,7 +9,6 @@ RUN dnf install -y --allowerasing \
       python3-dnf-plugin-versionlock \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \

--- a/openeuler-24.03/Containerfile
+++ b/openeuler-24.03/Containerfile
@@ -8,7 +8,6 @@ RUN dnf install -y --allowerasing \
       python3-dnf-plugin-versionlock \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \

--- a/rockylinux-10/Containerfile
+++ b/rockylinux-10/Containerfile
@@ -24,7 +24,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 

--- a/rockylinux-10/Containerfile-fixed
+++ b/rockylinux-10/Containerfile-fixed
@@ -30,7 +30,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 

--- a/rockylinux-10/Containerfile-vault
+++ b/rockylinux-10/Containerfile-vault
@@ -31,7 +31,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 

--- a/rockylinux-10/Makefile
+++ b/rockylinux-10/Makefile
@@ -1,5 +1,6 @@
 .PHONY: all
 all: Containerfile-10.0
+all: Containerfile-10.1
 
 .PHONY: clean
 clean:
@@ -8,5 +9,5 @@ clean:
 Containerfile-10.%: Containerfile-vault
 	env release=10.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-10.0: Containerfile-fixed
-	env release=10.0 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-10.1: Containerfile-fixed
+	env release=10.1 envsubst '$$release' <Containerfile-fixed >$@

--- a/rockylinux-8/Containerfile
+++ b/rockylinux-8/Containerfile
@@ -4,7 +4,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -25,7 +24,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf clean all
 
 RUN systemctl unmask \
@@ -37,6 +35,8 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
+RUN userdel unbound # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/rockylinux-8/Containerfile-fixed
+++ b/rockylinux-8/Containerfile-fixed
@@ -7,7 +7,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -28,7 +27,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf clean all
 
 RUN systemctl unmask \
@@ -40,6 +38,8 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
+RUN userdel unbound # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/rockylinux-8/Containerfile-vault
+++ b/rockylinux-8/Containerfile-vault
@@ -11,7 +11,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -32,7 +31,6 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf clean all
 
 RUN systemctl unmask \
@@ -44,6 +42,7 @@ RUN systemctl unmask \
       systemd-remount-fs.service
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/rockylinux-8/fixed
+++ b/rockylinux-8/fixed
@@ -11,7 +11,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \

--- a/rockylinux-9/Containerfile
+++ b/rockylinux-9/Containerfile
@@ -4,7 +4,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -25,11 +24,11 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/rockylinux-9/Containerfile-fixed
+++ b/rockylinux-9/Containerfile-fixed
@@ -10,7 +10,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -31,11 +30,11 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/rockylinux-9/Containerfile-vault
+++ b/rockylinux-9/Containerfile-vault
@@ -11,7 +11,6 @@ RUN dnf update -y \
     && dnf install -y --allowerasing \
       coreutils \
       cpio \
-      dhclient \
       e2fsprogs \
       ethtool \
       findutils \
@@ -32,11 +31,11 @@ RUN dnf update -y \
       strace \
       wget \
       which \
-      words \
     && dnf remove -y selinux-policy \
     && dnf clean all
 
 RUN chmod u+w / # https://github.com/openhpc/ohpc/issues/2061
+RUN userdel systemd-coredump # remove unused dynamic system user
 
 COPY excludes /etc/warewulf/
 COPY container_exit.sh /etc/warewulf/

--- a/rockylinux-9/Makefile
+++ b/rockylinux-9/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
-all: Containerfile-9.5
 all: Containerfile-9.6
+all: Containerfile-9.7
 
 .PHONY: clean
 clean:
@@ -9,5 +9,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.6: Containerfile-fixed
-	env release=9.6 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.7: Containerfile-fixed
+	env release=9.7 envsubst '$$release' <Containerfile-fixed >$@


### PR DESCRIPTION
Update to EL9.7 and EL10.1
* remove `dhclient` package (Thanks to @dubmarm and PR #90)
* remove `words` package
* remove `systemd-coredump` and `unbound` user in some images

Tested on qemu on MacOS for x86_64 and aarch64 for Rocky, Alma 8,9,10 with  Containers tested for 8 8.9 8.10 9 9.6 9.7 10 10.0 10.1 on aarch64
