### PR TITLE
Update AlmaLinux and Rokcy to EL 9.8 and 10.2

### DIFF
--- a/.github/workflows/container-publish.yml
+++ b/.github/workflows/container-publish.yml
@@ -40,25 +40,25 @@ jobs:
             context: rockylinux-9
             file: rockylinux-9/Containerfile
           - os: rockylinux
-            version: "9.6"
-            context: rockylinux-9
-            file: rockylinux-9/Containerfile-9.6
-          - os: rockylinux
             version: "9.7"
             context: rockylinux-9
             file: rockylinux-9/Containerfile-9.7
+          - os: rockylinux
+            version: "9.8"
+            context: rockylinux-9
+            file: rockylinux-9/Containerfile-9.8
           - os: rockylinux
             version: "10"
             context: rockylinux-10
             file: rockylinux-10/Containerfile
           - os: rockylinux
-            version: "10.0"
-            context: rockylinux-10
-            file: rockylinux-10/Containerfile-10.0
-          - os: rockylinux
             version: "10.1"
             context: rockylinux-10
             file: rockylinux-10/Containerfile-10.1
+          - os: rockylinux
+            version: "10.2"
+            context: rockylinux-10
+            file: rockylinux-10/Containerfile-10.2
           - os: almalinux
             version: "8"
             context: almalinux-8
@@ -76,25 +76,25 @@ jobs:
             context: almalinux-9
             file: almalinux-9/Containerfile
           - os: almalinux
-            version: "9.6"
-            context: almalinux-9
-            file: almalinux-9/Containerfile-9.6
-          - os: almalinux
             version: "9.7"
             context: almalinux-9
             file: almalinux-9/Containerfile-9.7
+          - os: almalinux
+            version: "9.8"
+            context: almalinux-9
+            file: almalinux-9/Containerfile-9.8
           - os: almalinux
             version: "10"
             context: almalinux-10
             file: almalinux-10/Containerfile
           - os: almalinux
-            version: "10.0"
-            context: almalinux-10
-            file: almalinux-10/Containerfile-10.0
-          - os: almalinux
             version: "10.1"
             context: almalinux-10
             file: almalinux-10/Containerfile-10.1
+          - os: almalinux
+            version: "10.2"
+            context: almalinux-10
+            file: almalinux-10/Containerfile-10.2
           - os: leap
             version: "15"
             context: leap

--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ These containers are published on the [GitHub container registry][1].
 * [AlmaLinux 10](almalinux-10)
 * [openEuler 24.03](openeuler-24.03)
 * [openSUSE Leap](leap)
+* [openSUSE Tumbleweed](tumbleweed)
+* [Debian](debian)
+* [Ubuntu](ubuntu)
 
 ## Additional examples
 

--- a/almalinux-10/Makefile
+++ b/almalinux-10/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
-all: Containerfile-10.0
 all: Containerfile-10.1
+all: Containerfile-10.2
 
 .PHONY: clean
 clean:
@@ -9,5 +9,5 @@ clean:
 Containerfile-10.%: Containerfile-vault
 	env release=10.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-10.1: Containerfile-fixed
-	env release=10.1 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-10.2: Containerfile-fixed
+	env release=10.2 envsubst '$$release' <Containerfile-fixed >$@

--- a/almalinux-9/Makefile
+++ b/almalinux-9/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
-all: Containerfile-9.6
 all: Containerfile-9.7
+all: Containerfile-9.8
 
 .PHONY: clean
 clean:
@@ -9,5 +9,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.7: Containerfile-fixed
-	env release=9.7 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.8: Containerfile-fixed
+	env release=9.8 envsubst '$$release' <Containerfile-fixed >$@

--- a/rockylinux-10/Makefile
+++ b/rockylinux-10/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
-all: Containerfile-10.0
 all: Containerfile-10.1
+all: Containerfile-10.2
 
 .PHONY: clean
 clean:
@@ -9,5 +9,5 @@ clean:
 Containerfile-10.%: Containerfile-vault
 	env release=10.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-10.1: Containerfile-fixed
-	env release=10.1 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-10.2: Containerfile-fixed
+	env release=10.2 envsubst '$$release' <Containerfile-fixed >$@

--- a/rockylinux-9/Makefile
+++ b/rockylinux-9/Makefile
@@ -1,6 +1,6 @@
 .PHONY: all
-all: Containerfile-9.6
 all: Containerfile-9.7
+all: Containerfile-9.8
 
 .PHONY: clean
 clean:
@@ -9,5 +9,5 @@ clean:
 Containerfile-9.%: Containerfile-vault
 	env release=9.$* envsubst '$$release' <Containerfile-vault >$@
 
-Containerfile-9.7: Containerfile-fixed
-	env release=9.7 envsubst '$$release' <Containerfile-fixed >$@
+Containerfile-9.8: Containerfile-fixed
+	env release=9.8 envsubst '$$release' <Containerfile-fixed >$@


### PR DESCRIPTION
* AlmaLinux 9: add 9.8 (fixed mirrors), keep 9.7 (vault)
* AlmaLinux 10: add 10.2 (fixed mirrors), keep 10.1 (vault)
* README: add openSUSE Tumbleweed, Debian, Ubuntu to built examples list
* Rocky Linux 9.8/10.2 pending upstream container image publish

Also add Tumbleweed/Debian/Ubuntu to README 

Tested almalinux 10.x 9.x on aarch64 on qemu/Mac M3